### PR TITLE
chore(security): add minimum-release-age to prevent some malicious security updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,7 +17,7 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "major"],
-      "delay": "5 days"
     }
-  ]
+  ],
+  "minimumReleaseAge": "5 days",
 }


### PR DESCRIPTION
See https://docs.renovatebot.com/configuration-options/#minimumreleaseage
This is a measure of https://github.com/homarr-labs/homarr/security/advisories/GHSA-r44g-gjcw-rvc6

Moved from https://github.com/homarr-labs/homarr/pull/3838