### PR TITLE
chore(renovate): add alloed-commands to config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,5 +18,8 @@
       "matchUpdateTypes": ["minor", "patch", "major"]
     }
   ],
-  "minimumReleaseAge": "5 days"
+  "minimumReleaseAge": "5 days",
+  "allowedCommands": [
+    "^cd deployments\/prebuilt-debian && pnpm install --ignore-workspace --lockfile-only$"
+  ]
 }


### PR DESCRIPTION
Related to https://github.com/homarr-labs/homarr/pull/5379

```
2026-04-01T17:56:16.4584395Z  WARN: Post-upgrade task did not match any on allowedCommands list (repository=homarr-labs/homarr, baseBranch=dev, branch=renovate/drizzle-orm-0-x)
2026-04-01T17:56:16.4587671Z        "dep": "drizzle-orm",
2026-04-01T17:56:16.4590169Z        "cmd": "cd deployments/prebuilt-debian && pnpm install --ignore-workspace --lockfile-only",
2026-04-01T17:56:16.4591216Z        "allowedCommands": []
```