### PR TITLE
chore(chart): disable minimumReleaseAge for homarr image

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,7 +15,8 @@
   "prConcurrentLimit": 30,
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch", "major"]
+      "matchUpdateTypes": ["minor", "patch", "major"],
+      "matchPackageNames": ["ghcr.io/homarr-labs/**"], "minimumReleaseAge": null
     }
   ],
   "minimumReleaseAge": "5 days",


### PR DESCRIPTION
## Problem

  Renovate stopped creating PRs for `ghcr.io/homarr-labs/homarr` tag updates
  (nothing since v1.60.0 — v1.61–v1.69.x were never proposed).

  ## Root cause

  Our global config sets `minimumReleaseAge: "5 days"`. Renovate 43 (picked up
  May 7 via the floating `renovate:43` image in `github-action@v46`) changed the
  default `minimumReleaseAgeBehaviour` to `timestamp-required`: releases without
  a timestamp now fail the age check permanently. ghcr.io tags expose no
  timestamps, so every new tag is stuck "pending" forever and no PR is created.
  With `dependencyDashboard: false`, this was invisible.

  Confirmed via dry run against `charts@dev`:

      DEBUG: Marking 4 release(s) as pending, as they do not have a releaseTimestamp
             and we're running with minimumReleaseAgeBehaviour=timestamp-required

  ## Fix

  Skip the cooldown for our own images only; third-party deps keep the 5-day protection:                                                                        

      { "matchPackageNames": ["ghcr.io/homarr-labs/**"], "minimumReleaseAge": null }